### PR TITLE
Fix formatting of invoice item insertion

### DIFF
--- a/POS/src/composables/useInvoice.js
+++ b/POS/src/composables/useInvoice.js
@@ -103,7 +103,7 @@ export function useInvoice() {
 			existingItem.quantity += quantity
 			recalculateItem(existingItem)
 		} else {
-			invoiceItems.value.push({
+			invoiceItems.value.unshift({
 				item_code: item.item_code,
 				item_name: item.item_name,
 				rate: item.rate || item.price_list_rate || 0,


### PR DESCRIPTION
## Summary
- restore tab-indented formatting in the addItem branch
- keep newly added invoice items inserted at the top of the cart

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e11356ab7c8326b2f3e30db4ae1c54