### PR TITLE
Convert POS item selector pricing to stock UOM

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -184,9 +184,9 @@
 									<h4 class="text-xs font-semibold text-gray-900 truncate">
 										{{ item.item_name }}
 									</h4>
-									<p class="text-[10px] text-gray-500">
-										{{ formatCurrency(item.rate) }} / {{ item.stock_uom || 'Nos' }}
-									</p>
+                                                                        <p class="text-[10px] text-gray-500">
+                                                                                {{ formatCurrency(item.rate) }} / {{ item.uom || item.stock_uom || 'Nos' }}
+                                                                        </p>
 								</div>
 								<button
 									@click="$emit('remove-item', item.item_code)"
@@ -388,12 +388,12 @@ const props = defineProps({
 	posProfile: String,
 	currency: {
 		type: String,
-		default: 'USD'
+		default: "USD",
 	},
 	appliedOffer: {
 		type: Object,
-		default: null
-	}
+		default: null,
+	},
 })
 
 const emit = defineEmits([
@@ -425,12 +425,12 @@ const customersResource = createResource({
 	url: "pos_next.api.customers.get_customers",
 	makeParams() {
 		return {
-			search_term: "",  // Empty to get all customers
+			search_term: "", // Empty to get all customers
 			pos_profile: props.posProfile,
-			limit: 9999  // Get all customers
+			limit: 9999, // Get all customers
 		}
 	},
-	auto: true,  // Auto-load on mount
+	auto: true, // Auto-load on mount
 	async onSuccess(data) {
 		const customers = data?.message || data || []
 		allCustomers.value = customers
@@ -442,7 +442,7 @@ const customersResource = createResource({
 	},
 	onError(error) {
 		console.error("Error loading customers:", error)
-	}
+	},
 })
 
 // Load offers resource
@@ -450,26 +450,26 @@ const offersResource = createResource({
 	url: "pos_next.api.offers.get_offers",
 	makeParams() {
 		return {
-			pos_profile: props.posProfile
+			pos_profile: props.posProfile,
 		}
 	},
 	auto: true,
 	onSuccess(data) {
 		const offers = data?.message || data || []
-		console.log('✓ Loaded offers:', offers.length, offers)
+		console.log("✓ Loaded offers:", offers.length, offers)
 
 		// Filter only auto-apply offers that are eligible
-		const eligible = offers.filter(offer =>
-			offer.auto && !offer.coupon_based &&
-			checkOfferEligibility(offer)
+		const eligible = offers.filter(
+			(offer) =>
+				offer.auto && !offer.coupon_based && checkOfferEligibility(offer),
 		)
 
-		console.log('✓ Eligible offers:', eligible.length, eligible)
+		console.log("✓ Eligible offers:", eligible.length, eligible)
 		availableOffers.value = eligible.slice(0, 3) // Show top 3
 	},
 	onError(error) {
-		console.error('Error loading offers:', error)
-	}
+		console.error("Error loading offers:", error)
+	},
 })
 
 // Load gift cards resource
@@ -478,34 +478,42 @@ const giftCardsResource = createResource({
 	makeParams() {
 		return {
 			customer: props.customer?.name || props.customer,
-			company: props.posProfile // Will get company from profile
+			company: props.posProfile, // Will get company from profile
 		}
 	},
 	auto: false,
 	onSuccess(data) {
 		availableGiftCards.value = data?.message || data || []
-	}
+	},
 })
 
 // Watch for customer changes to load their gift cards
-watch(() => props.customer, (newCustomer) => {
-	if (newCustomer && props.posProfile) {
-		giftCardsResource.reload()
-	} else {
-		availableGiftCards.value = []
-	}
-})
+watch(
+	() => props.customer,
+	(newCustomer) => {
+		if (newCustomer && props.posProfile) {
+			giftCardsResource.reload()
+		} else {
+			availableGiftCards.value = []
+		}
+	},
+)
 
 // Watch for cart changes to update eligible offers
-watch(() => props.grandTotal, () => {
-	if (offersResource.data) {
-		const offers = offersResource.data?.message || offersResource.data || []
-		availableOffers.value = offers.filter(offer =>
-			offer.auto && !offer.coupon_based &&
-			checkOfferEligibility(offer)
-		).slice(0, 3)
-	}
-})
+watch(
+	() => props.grandTotal,
+	() => {
+		if (offersResource.data) {
+			const offers = offersResource.data?.message || offersResource.data || []
+			availableOffers.value = offers
+				.filter(
+					(offer) =>
+						offer.auto && !offer.coupon_based && checkOfferEligibility(offer),
+				)
+				.slice(0, 3)
+		}
+	},
+)
 
 // Computed top offer for preview
 const topOffer = computed(() => {
@@ -534,15 +542,19 @@ const customerResults = computed(() => {
 	}
 
 	// Instant in-memory filter
-	return allCustomers.value.filter(cust => {
-		const name = (cust.customer_name || '').toLowerCase()
-		const mobile = (cust.mobile_no || '').toLowerCase()
-		const id = (cust.name || '').toLowerCase()
+	return allCustomers.value
+		.filter((cust) => {
+			const name = (cust.customer_name || "").toLowerCase()
+			const mobile = (cust.mobile_no || "").toLowerCase()
+			const id = (cust.name || "").toLowerCase()
 
-		return name.includes(searchValue) ||
-		       mobile.includes(searchValue) ||
-		       id.includes(searchValue)
-	}).slice(0, 20)
+			return (
+				name.includes(searchValue) ||
+				mobile.includes(searchValue) ||
+				id.includes(searchValue)
+			)
+		})
+		.slice(0, 20)
 })
 
 // Reset selection when results change
@@ -563,21 +575,27 @@ function handleSearchInput(event) {
 function handleKeydown(event) {
 	if (customerResults.value.length === 0) return
 
-	if (event.key === 'ArrowDown') {
+	if (event.key === "ArrowDown") {
 		event.preventDefault()
-		selectedIndex.value = Math.min(selectedIndex.value + 1, customerResults.value.length - 1)
-	} else if (event.key === 'ArrowUp') {
+		selectedIndex.value = Math.min(
+			selectedIndex.value + 1,
+			customerResults.value.length - 1,
+		)
+	} else if (event.key === "ArrowUp") {
 		event.preventDefault()
 		selectedIndex.value = Math.max(selectedIndex.value - 1, -1)
-	} else if (event.key === 'Enter') {
+	} else if (event.key === "Enter") {
 		event.preventDefault()
-		if (selectedIndex.value >= 0 && selectedIndex.value < customerResults.value.length) {
+		if (
+			selectedIndex.value >= 0 &&
+			selectedIndex.value < customerResults.value.length
+		) {
 			selectCustomer(customerResults.value[selectedIndex.value])
 		} else if (customerResults.value.length === 1) {
 			// Auto-select if only one result
 			selectCustomer(customerResults.value[0])
 		}
-	} else if (event.key === 'Escape') {
+	} else if (event.key === "Escape") {
 		customerSearch.value = ""
 	}
 }
@@ -633,17 +651,17 @@ function applyTopOffer() {
 
 	// Just open the offers dialog - don't set preview yet
 	// Preview will be set when user actually selects an offer in the dialog
-	emit('show-offers')
+	emit("show-offers")
 }
 
 function removeAppliedOffer() {
-	emit('remove-offer')
+	emit("remove-offer")
 }
 
 // Close dropdown when clicking outside
-if (typeof document !== 'undefined') {
-	document.addEventListener('click', (e) => {
-		if (!e.target.closest('.relative')) {
+if (typeof document !== "undefined") {
+	document.addEventListener("click", (e) => {
+		if (!e.target.closest(".relative")) {
 			customerSearch.value = ""
 		}
 	})

--- a/POS/src/components/sale/ItemsSelector.vue
+++ b/POS/src/components/sale/ItemsSelector.vue
@@ -203,10 +203,10 @@
 							<h3 class="text-xs font-semibold text-gray-900 truncate mb-0.5 leading-tight">
 								{{ item.item_name }}
 							</h3>
-							<p class="text-[10px] text-gray-500">
-								{{ formatCurrency(item.rate || item.price_list_rate || 0) }}
-								<span class="text-gray-400">/ {{ item.stock_uom || 'Nos' }}</span>
-							</p>
+                                                        <p class="text-[10px] text-gray-500">
+                                                                {{ formatCurrency(item.rate || item.price_list_rate || 0) }}
+                                                                <span class="text-gray-400">/ {{ item.uom || item.stock_uom || 'Nos' }}</span>
+                                                        </p>
 						</div>
 					</div>
 				</div>
@@ -300,7 +300,7 @@
 									{{ Math.floor(item.actual_qty || item.stock_qty || 0) }}
 								</span>
 							</td>
-							<td class="px-3 py-2 whitespace-nowrap"><div class="text-sm text-gray-500">{{ item.stock_uom || 'Nos' }}</div></td>
+                                                        <td class="px-3 py-2 whitespace-nowrap"><div class="text-sm text-gray-500">{{ item.uom || item.stock_uom || 'Nos' }}</div></td>
 						</tr>
 					</tbody>
 				</table>
@@ -371,24 +371,25 @@ const props = defineProps({
 	posProfile: String,
 	cartItems: {
 		type: Array,
-		default: () => []
+		default: () => [],
 	},
 	currency: {
 		type: String,
-		default: 'USD'
-	}
+		default: "USD",
+	},
 })
 
 const emit = defineEmits(["item-selected"])
 
 // Use Pinia store
 const itemStore = useItemSearchStore()
-const { filteredItems, searchTerm, selectedItemGroup, itemGroups, loading } = storeToRefs(itemStore)
+const { filteredItems, searchTerm, selectedItemGroup, itemGroups, loading } =
+	storeToRefs(itemStore)
 
 // Local state
-const viewMode = ref('grid')
+const viewMode = ref("grid")
 const lastKeyTime = ref(0)
-const barcodeBuffer = ref('')
+const barcodeBuffer = ref("")
 const searchInputRef = ref(null)
 const scannerEnabled = ref(false)
 const itemThreshold = ref(50) // Threshold for auto-switching to list view
@@ -413,38 +414,54 @@ const totalPages = computed(() => {
 })
 
 // Watch for cart items and pos profile changes
-watch(() => props.cartItems, (newCartItems) => {
-	itemStore.setCartItems(newCartItems)
-}, { immediate: true, deep: true })
+watch(
+	() => props.cartItems,
+	(newCartItems) => {
+		itemStore.setCartItems(newCartItems)
+	},
+	{ immediate: true, deep: true },
+)
 
-watch(() => props.posProfile, (newProfile) => {
-	if (newProfile) {
-		itemStore.setPosProfile(newProfile)
-	}
-}, { immediate: true })
+watch(
+	() => props.posProfile,
+	(newProfile) => {
+		if (newProfile) {
+			itemStore.setPosProfile(newProfile)
+		}
+	},
+	{ immediate: true },
+)
 
 // Reset to page 1 when filtered items change
-watch(filteredItems, (newItems) => {
-	if (!newItems) return
+watch(
+	filteredItems,
+	(newItems) => {
+		if (!newItems) return
 
-	const itemCount = newItems.length
+		const itemCount = newItems.length
 
-	// Reset pagination when items change
-	currentPage.value = 1
+		// Reset pagination when items change
+		currentPage.value = 1
 
-	// Only auto-switch if user hasn't manually set a preference
-	// and we're in grid view with many items
-	if (!userManuallySetView.value && viewMode.value === 'grid' && itemCount > itemThreshold.value) {
-		viewMode.value = 'list'
+		// Only auto-switch if user hasn't manually set a preference
+		// and we're in grid view with many items
+		if (
+			!userManuallySetView.value &&
+			viewMode.value === "grid" &&
+			itemCount > itemThreshold.value
+		) {
+			viewMode.value = "list"
 
-		toast.create({
-			title: "Switched to List View",
-			text: `Displaying ${itemCount} items - automatically switched to list view for better performance`,
-			icon: "list",
-			iconClasses: "text-blue-600",
-		})
-	}
-}, { immediate: false })
+			toast.create({
+				title: "Switched to List View",
+				text: `Displaying ${itemCount} items - automatically switched to list view for better performance`,
+				icon: "list",
+				iconClasses: "text-blue-600",
+			})
+		}
+	},
+	{ immediate: false },
+)
 
 onMounted(() => {
 	if (props.posProfile) {
@@ -459,10 +476,10 @@ function handleKeyDown(event) {
 	const timeDiff = currentTime - lastKeyTime.value
 
 	// If Enter is pressed, always trigger search
-	if (event.key === 'Enter') {
+	if (event.key === "Enter") {
 		event.preventDefault()
 		handleBarcodeSearch()
-		barcodeBuffer.value = ''
+		barcodeBuffer.value = ""
 		return
 	}
 
@@ -472,7 +489,7 @@ function handleKeyDown(event) {
 		barcodeBuffer.value += event.key
 	} else {
 		// Manual typing - reset buffer
-		barcodeBuffer.value = event.key.length === 1 ? event.key : ''
+		barcodeBuffer.value = event.key.length === 1 ? event.key : ""
 	}
 
 	lastKeyTime.value = currentTime
@@ -515,7 +532,7 @@ async function handleBarcodeSearch() {
 			return
 		}
 	} catch (error) {
-		console.error('Barcode API error:', error)
+		console.error("Barcode API error:", error)
 	}
 
 	// Fallback: If only one item matches in filtered results, auto-select it
@@ -565,7 +582,7 @@ function toggleBarcodeScanner() {
 
 	// Focus on search input when enabling scanner
 	if (scannerEnabled.value) {
-		const input = searchInputRef.value || document.getElementById('item-search')
+		const input = searchInputRef.value || document.getElementById("item-search")
 		if (input) {
 			input.focus()
 		}


### PR DESCRIPTION
## Summary
- convert POS item pricing to the item's stock UOM so selector rates match the default unit displayed
- fetch UOM conversion factors in bulk and expose price list UOM metadata for the frontend when a different unit is configured

## Testing
- python -m compileall pos_next/api/items.py

------
https://chatgpt.com/codex/tasks/task_e_68e60740013883268c0178d362dbd837