### PR TITLE
Fix auto-applied offers when quantity decreases

### DIFF
--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -1260,43 +1260,43 @@ async function autoApplyOffers() {
 
 		const result = await applyOffersResource.submit({ invoice_data: invoiceData })
 
-		if (result && result.items) {
-			let hasDiscounts = false
-			const discountedItems = []
+                if (result && result.items) {
+                        let hasDiscounts = false
 
-			// Collect items with discounts
-			result.items.forEach(serverItem => {
-				const cartItem = invoiceItems.value.find(i => i.item_code === serverItem.item_code)
-				if (cartItem && serverItem.discount_percentage > 0) {
-					discountedItems.push({
-						item: cartItem,
-						discount_percentage: serverItem.discount_percentage,
-						discount_amount: serverItem.discount_amount || 0
-					})
-					hasDiscounts = true
-				}
-			})
+                        result.items.forEach(serverItem => {
+                                const cartItem = invoiceItems.value.find(i => i.item_code === serverItem.item_code)
 
-			// Apply all discounts at once using the composable
-			if (hasDiscounts) {
-				discountedItems.forEach(({ item, discount_percentage, discount_amount }) => {
-					item.discount_percentage = discount_percentage
-					item.discount_amount = discount_amount
-					updateItemQuantity(item.item_code, item.quantity)
-				})
+                                if (!cartItem) {
+                                        return
+                                }
 
-				autoAppliedOffer.value = { name: "Auto Offer", applied: true }
+                                const discountPercentage = serverItem.discount_percentage || 0
+                                const discountAmount = serverItem.discount_amount || 0
 
-				toast.create({
-					title: "Offers Applied",
-					text: "Eligible offers have been applied to your cart",
-					icon: "check",
-					iconClasses: "text-green-600",
-				})
-			} else {
-				autoAppliedOffer.value = null
-			}
-		}
+                                if (discountPercentage > 0 || discountAmount > 0) {
+                                        hasDiscounts = true
+                                }
+
+                                cartItem.discount_percentage = discountPercentage
+                                cartItem.discount_amount = discountAmount
+
+                                // Trigger a recalculation so the UI updates totals/taxes correctly
+                                updateItemQuantity(cartItem.item_code, cartItem.quantity)
+                        })
+
+                        if (hasDiscounts) {
+                                autoAppliedOffer.value = { name: "Auto Offer", applied: true }
+
+                                toast.create({
+                                        title: "Offers Applied",
+                                        text: "Eligible offers have been applied to your cart",
+                                        icon: "check",
+                                        iconClasses: "text-green-600",
+                                })
+                        } else {
+                                autoAppliedOffer.value = null
+                        }
+                }
 	} catch (error) {
 		// Silently fail - don't interrupt the user experience
 		console.error("Error auto-applying offers:", error)


### PR DESCRIPTION
## Summary
- update auto-apply offer handling to sync discounts for all line items
- ensure previously applied discounts are cleared when the backend no longer returns them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e612b3d57c8326a257d79d3a0fc8f0