### PR TITLE
Fix manual offer application loops and improve offer filtering

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -454,19 +454,15 @@ const offersResource = createResource({
 		}
 	},
 	auto: true,
-	onSuccess(data) {
-		const offers = data?.message || data || []
-		console.log("✓ Loaded offers:", offers.length, offers)
+        onSuccess(data) {
+                const offers = data?.message || data || []
+                console.log("✓ Loaded offers:", offers.length, offers)
 
-		// Filter only auto-apply offers that are eligible
-		const eligible = offers.filter(
-			(offer) =>
-				offer.auto && !offer.coupon_based && checkOfferEligibility(offer),
-		)
-
-		console.log("✓ Eligible offers:", eligible.length, eligible)
-		availableOffers.value = eligible.slice(0, 3) // Show top 3
-	},
+                const sorted = sortOffersForPreview(offers)
+                const eligible = sorted.filter(checkOfferEligibility)
+                console.log("✓ Eligible offers:", eligible.length, eligible)
+                availableOffers.value = sorted.slice(0, 3) // Show top 3 suggestions
+        },
 	onError(error) {
 		console.error("Error loading offers:", error)
 	},
@@ -502,17 +498,13 @@ watch(
 // Watch for cart changes to update eligible offers
 watch(
 	() => props.grandTotal,
-	() => {
-		if (offersResource.data) {
-			const offers = offersResource.data?.message || offersResource.data || []
-			availableOffers.value = offers
-				.filter(
-					(offer) =>
-						offer.auto && !offer.coupon_based && checkOfferEligibility(offer),
-				)
-				.slice(0, 3)
-		}
-	},
+        () => {
+                if (offersResource.data) {
+                        const offers = offersResource.data?.message || offersResource.data || []
+                        const sorted = sortOffersForPreview(offers)
+                        availableOffers.value = sorted.slice(0, 3)
+                }
+        },
 )
 
 // Computed top offer for preview
@@ -523,14 +515,37 @@ const topOffer = computed(() => {
 })
 
 function checkOfferEligibility(offer) {
-	// Check eligibility based on SUBTOTAL (before tax)
-	if (offer.min_amt && props.subtotal < offer.min_amt) {
-		return false
-	}
-	if (offer.max_amt && props.subtotal > offer.max_amt) {
-		return false
-	}
-	return true
+        // Check eligibility based on SUBTOTAL (before tax)
+        if (offer.min_amt && props.subtotal < offer.min_amt) {
+                return false
+        }
+        if (offer.max_amt && props.subtotal > offer.max_amt) {
+                return false
+        }
+        if (offer.min_qty) {
+                const totalQty = props.items.reduce((sum, item) => sum + item.quantity, 0)
+                if (totalQty < offer.min_qty) {
+                        return false
+                }
+        }
+        return true
+}
+
+function sortOffersForPreview(offers) {
+        const filtered = (offers || []).filter((offer) => !offer.coupon_based)
+        return filtered.sort((a, b) => {
+                const aEligible = checkOfferEligibility(a)
+                const bEligible = checkOfferEligibility(b)
+                if (aEligible !== bEligible) return bEligible ? 1 : -1
+
+                if (a.auto !== b.auto) {
+                        return b.auto ? 1 : -1
+                }
+
+                const aValue = a.discount_percentage || a.discount_amount || 0
+                const bValue = b.discount_percentage || b.discount_amount || 0
+                return bValue - aValue
+        })
 }
 
 // Direct computed results - zero latency filtering!

--- a/POS/src/components/sale/OffersDialog.vue
+++ b/POS/src/components/sale/OffersDialog.vue
@@ -235,22 +235,26 @@ const offersResource = createResource({
 
 // Computed eligible offers
 const eligibleOffers = computed(() => {
-	if (!allOffers.value) return []
+        if (!allOffers.value) return []
 
-	// Filter for auto-apply offers only (not coupon-based)
-	return allOffers.value
-		.filter(offer => offer.auto && !offer.coupon_based)
-		.sort((a, b) => {
-			// Sort by eligibility first (eligible offers on top)
-			const aEligible = checkOfferEligibility(a)
-			const bEligible = checkOfferEligibility(b)
-			if (aEligible !== bEligible) return bEligible ? 1 : -1
+        return allOffers.value
+                .filter(offer => !offer.coupon_based)
+                .sort((a, b) => {
+                        // Sort by eligibility first (eligible offers on top)
+                        const aEligible = checkOfferEligibility(a)
+                        const bEligible = checkOfferEligibility(b)
+                        if (aEligible !== bEligible) return bEligible ? 1 : -1
 
-			// Then sort by discount value (higher discounts first)
-			const aValue = a.discount_percentage || a.discount_amount || 0
-			const bValue = b.discount_percentage || b.discount_amount || 0
-			return bValue - aValue
-		})
+                        // Prioritize auto offers when both share the same eligibility state
+                        if (a.auto !== b.auto) {
+                                return b.auto ? 1 : -1
+                        }
+
+                        // Then sort by discount value (higher discounts first)
+                        const aValue = a.discount_percentage || a.discount_amount || 0
+                        const bValue = b.discount_percentage || b.discount_amount || 0
+                        return bValue - aValue
+                })
 })
 
 watch(() => props.modelValue, (val) => {

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -621,6 +621,10 @@ const autoAppliedOffer = ref(null)
 const appliedCoupon = ref(null)
 const pendingPaymentAfterCustomer = ref(false)
 
+// Internal guards to avoid recursive re-application loops
+let isApplyingManualOffer = false
+let isProcessingAutoOffer = false
+
 // Get global dialog state for divider behavior
 const { isAnyDialogOpen } = useDialogState()
 
@@ -753,40 +757,65 @@ watch(hasOpenShift, value => {
 
 // Watch cart changes to auto-apply eligible offers with debouncing
 let autoApplyTimeout = null
-watch([invoiceItems, subtotal], async (newVal, oldVal) => {
-	// Clear any pending auto-apply
-	if (autoApplyTimeout) {
-		clearTimeout(autoApplyTimeout)
-	}
+watch([invoiceItems, subtotal], async () => {
+        // Clear any pending auto-apply
+        if (autoApplyTimeout) {
+                clearTimeout(autoApplyTimeout)
+        }
 
-	// Only auto-apply if:
-	// 1. Cart is not empty
-	// 2. POS profile is set
-	// 3. No offer is currently applied (to avoid overwriting manual selections)
-	if (invoiceItems.value.length > 0 && posProfile.value && !autoAppliedOffer.value) {
-		// Debounce for 500ms to avoid excessive API calls
-		autoApplyTimeout = setTimeout(async () => {
-			await autoApplyOffers()
-		}, 500)
-	} else if (invoiceItems.value.length === 0) {
-		// Clear auto-applied offers when cart is emptied
-		autoAppliedOffer.value = null
-	}
+        // Only auto-apply if:
+        // 1. Cart is not empty
+        // 2. POS profile is set
+        // 3. No offer is currently applied (to avoid overwriting manual selections)
+        if (invoiceItems.value.length > 0 && posProfile.value && !autoAppliedOffer.value) {
+                // Debounce for 500ms to avoid excessive API calls
+                autoApplyTimeout = setTimeout(async () => {
+                        await autoApplyOffers()
+                }, 500)
+        } else if (invoiceItems.value.length === 0) {
+                // Clear auto-applied offers when cart is emptied
+                autoAppliedOffer.value = null
+        }
 }, { deep: true })
 
 // Watch for items changes and re-apply offer if one is already applied
-watch(invoiceItems, () => {
-	if (autoAppliedOffer.value && invoiceItems.value.length > 0) {
-		// Re-apply the current offer to new items
-		applyDiscount(autoAppliedOffer.value)
-	}
+watch(invoiceItems, async () => {
+        if (!autoAppliedOffer.value || invoiceItems.value.length === 0) {
+                return
+        }
+
+        // Prevent recursive loops when we are already adjusting discounts
+        if (autoAppliedOffer.value?.__type === "manual") {
+                if (isApplyingManualOffer) {
+                        return
+                }
+                applyOfferWithGuard(autoAppliedOffer.value)
+        } else if (autoAppliedOffer.value?.__type === "auto") {
+                if (isProcessingAutoOffer) {
+                        return
+                }
+                await autoApplyOffers()
+        }
 }, { deep: true })
 
+function applyOfferWithGuard(offer) {
+        if (!offer) {
+                return
+        }
+
+        try {
+                isApplyingManualOffer = true
+                applyDiscount(offer)
+        } finally {
+                isApplyingManualOffer = false
+        }
+}
+
 onUnmounted(() => {
-	// Clean up timeout
-	if (autoApplyTimeout) {
-		clearTimeout(autoApplyTimeout)
-	}
+        // Clean up timeout
+        if (autoApplyTimeout) {
+                clearTimeout(autoApplyTimeout)
+        }
 
 	// Clean up event listeners
 	document.removeEventListener('click', handleClickOutside)
@@ -1180,10 +1209,11 @@ function handleReturnCreated(returnInvoice) {
 }
 
 function handleDiscountApplied(discount) {
-	// Use the composable's applyDiscount function
-	applyDiscount(discount)
-	appliedCoupon.value = discount
-	showCouponDialog.value = false
+        // Use the composable's applyDiscount function
+        applyDiscount(discount)
+        autoAppliedOffer.value = null
+        appliedCoupon.value = discount
+        showCouponDialog.value = false
 
 	toast.create({
 		title: "Coupon Applied",
@@ -1208,12 +1238,12 @@ function handleDiscountRemoved() {
 }
 
 function handleOfferApplied(offer) {
-	// Use the composable's applyDiscount function
-	applyDiscount(offer)
-	autoAppliedOffer.value = offer
-	showOffersDialog.value = false
+        // Use guarded discount application to avoid recursive watchers
+        applyOfferWithGuard(offer)
+        autoAppliedOffer.value = { ...offer, __type: "manual" }
+        showOffersDialog.value = false
 
-	toast.create({
+        toast.create({
 		title: "Offer Applied",
 		text: `${offer.name} applied successfully`,
 		icon: "check",
@@ -1235,13 +1265,18 @@ function handleOfferRemoved() {
 }
 
 async function autoApplyOffers() {
-	// Automatically apply eligible offers from the backend
-	try {
-		// Clear auto-applied flag if cart is empty
-		if (invoiceItems.value.length === 0) {
-			autoAppliedOffer.value = null
-			return
-		}
+        if (isProcessingAutoOffer) {
+                return
+        }
+
+        isProcessingAutoOffer = true
+        // Automatically apply eligible offers from the backend
+        try {
+                // Clear auto-applied flag if cart is empty
+                if (invoiceItems.value.length === 0) {
+                        autoAppliedOffer.value = null
+                        return
+                }
 
 		const invoiceData = {
 			doctype: "Sales Invoice",
@@ -1285,7 +1320,12 @@ async function autoApplyOffers() {
 					updateItemQuantity(item.item_code, item.quantity)
 				})
 
-				autoAppliedOffer.value = { name: "Auto Offer", applied: true }
+                                autoAppliedOffer.value = {
+                                        name: "Auto Offer",
+                                        applied: true,
+                                        __type: "auto",
+                                        rules: result.applied_pricing_rules || [],
+                                }
 
 				toast.create({
 					title: "Offers Applied",
@@ -1294,13 +1334,15 @@ async function autoApplyOffers() {
 					iconClasses: "text-green-600",
 				})
 			} else {
-				autoAppliedOffer.value = null
-			}
-		}
-	} catch (error) {
-		// Silently fail - don't interrupt the user experience
-		console.error("Error auto-applying offers:", error)
-	}
+                                autoAppliedOffer.value = null
+                        }
+                }
+        } catch (error) {
+                // Silently fail - don't interrupt the user experience
+                console.error("Error auto-applying offers:", error)
+        } finally {
+                isProcessingAutoOffer = false
+        }
 }
 
 function handleBatchSerialSelected(batchSerial) {


### PR DESCRIPTION
## Summary
- prevent recursive discount loops when manually applying POS offers
- track manual vs auto offers and reapply or refresh them without locking the UI
- expose non-auto offers in the offer dialog and quick preview with improved eligibility checks

## Testing
- yarn test:run *(fails: Yarn workspace configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_68e63d7e08488326bb74d72859421aca