### PR TITLE
feat: make source maps configurable

### DIFF
--- a/POS/README.md
+++ b/POS/README.md
@@ -41,6 +41,10 @@ The development server is configured to proxy your frappe app (usually running o
 If you notice the browser URL is `/frontend`, this is the base URL where your frontend app will run in production.
 To change this, open `src/router.js` and change the base URL passed to `createWebHistory`.
 
+## Source maps in production builds
+
+Production builds omit JavaScript source maps by default to keep bundle sizes small. If you need source maps for debugging a specific deployment, set the environment variable `POS_NEXT_ENABLE_SOURCEMAP=true` before running the build command. Any value other than the string `"true"` will keep source maps disabled.
+
 ## Resources
 
 - [Vue 3](https://v3.vuejs.org/guide/introduction.html)

--- a/POS/vite.config.js
+++ b/POS/vite.config.js
@@ -8,6 +8,7 @@ import { viteStaticCopy } from "vite-plugin-static-copy"
 
 // Get build version from environment or use timestamp
 const buildVersion = process.env.POS_NEXT_BUILD_VERSION || Date.now().toString()
+const enableSourceMap = process.env.POS_NEXT_ENABLE_SOURCEMAP === "true"
 
 /**
  * Vite plugin to write build version to version.json file
@@ -54,7 +55,7 @@ export default defineConfig({
 				indexHtmlPath: "../pos_next/www/pos.html",
 				outDir: "../pos_next/public/pos",
 				emptyOutDir: true,
-				sourcemap: true,
+				sourcemap: enableSourceMap,
 			},
 		}),
 		vue(),
@@ -210,7 +211,7 @@ export default defineConfig({
 		outDir: "../pos_next/public/pos",
 		emptyOutDir: true,
 		target: "es2015",
-		sourcemap: true,
+		sourcemap: enableSourceMap,
 	},
 	worker: {
 		format: "es",


### PR DESCRIPTION
## Summary
- add POS_NEXT_ENABLE_SOURCEMAP flag to control whether Vite builds emit source maps
- wire the new flag into both frappeui and top-level build configurations
- document how to enable the opt-in source maps toggle in the POS README

## Testing
- not run
