### PR TITLE
Load all customers without hardcoded limits

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -751,12 +751,12 @@ const openUomDropdown = ref(null)
 const customersResource = createResource({
 	url: "pos_next.api.customers.get_customers",
 	makeParams() {
-		return {
-			search_term: "", // Empty to get all customers
-			pos_profile: props.posProfile,
-			limit: 9999, // Get all customers
-		}
-	},
+                return {
+                        search_term: "", // Empty to get all customers
+                        pos_profile: props.posProfile,
+                        limit: 0, // Get all customers
+                }
+        },
 	auto: false, // Don't auto-load - check offline status first
 	async onSuccess(data) {
 		const customers = data?.message || data || []
@@ -773,12 +773,12 @@ const customersResource = createResource({
 
 // Load customers from cache first (instant), then from server if online
 ;(async () => {
-	try {
-		// Always try cache first for instant load
-		const cachedCustomers = await offlineWorker.searchCachedCustomers("", 9999)
-		if (cachedCustomers && cachedCustomers.length > 0) {
-			allCustomers.value = cachedCustomers
-			customersLoaded.value = true
+        try {
+                // Always try cache first for instant load
+                const cachedCustomers = await offlineWorker.searchCachedCustomers("", 0)
+                if (cachedCustomers && cachedCustomers.length > 0) {
+                        allCustomers.value = cachedCustomers
+                        customersLoaded.value = true
 		}
 	} catch (error) {
 		console.error("Error loading customers from cache:", error)

--- a/POS/src/stores/customerSearch.js
+++ b/POS/src/stores/customerSearch.js
@@ -210,10 +210,10 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 		loading.value = true
 		try {
 			// Try to get from worker cache first
-			const cachedCustomers = await offlineWorker.searchCachedCustomers(
-				"",
-				9999,
-			)
+                        const cachedCustomers = await offlineWorker.searchCachedCustomers(
+                                "",
+                                0,
+                        )
 
 			if (cachedCustomers && cachedCustomers.length > 0) {
 				allCustomers.value = cachedCustomers
@@ -226,7 +226,7 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 					pos_profile: posProfile,
 					search_term: "",
 					start: 0,
-					limit: 9999,
+                                        limit: 0,
 				})
 				const list = response?.message || response || []
 				allCustomers.value = list

--- a/POS/src/utils/offline/cache.js
+++ b/POS/src/utils/offline/cache.js
@@ -187,11 +187,11 @@ export const cacheCustomersFromServer = async (posProfile) => {
 	try {
 		console.log("Fetching customers from server...")
 
-		const response = await call("pos_next.api.customers.get_customers", {
-			pos_profile: posProfile,
-			start: 0,
-			limit: 9999, // Get all customers
-		})
+                const response = await call("pos_next.api.customers.get_customers", {
+                        pos_profile: posProfile,
+                        start: 0,
+                        limit: 0, // Get all customers
+                })
 
 		if (response.message && Array.isArray(response.message)) {
 			const customers = response.message
@@ -236,25 +236,33 @@ export const searchCachedItems = async (searchTerm = "", limit = 50) => {
 
 // Search customers in cache
 export const searchCachedCustomers = async (searchTerm = "", limit = 50) => {
-	try {
-		if (!searchTerm) {
-			return await db.customers.limit(limit).toArray()
-		}
+        try {
+                const shouldLimit = Number.isFinite(limit) && limit > 0
 
-		const term = searchTerm.toLowerCase()
+                if (!searchTerm) {
+                        return shouldLimit
+                                ? await db.customers.limit(limit).toArray()
+                                : await db.customers.toArray()
+                }
 
-		// Search by name, mobile, or email
-		const results = await db.customers
-			.where("customer_name")
-			.startsWithIgnoreCase(term)
-			.or("mobile_no")
-			.startsWithIgnoreCase(term)
-			.or("email_id")
-			.startsWithIgnoreCase(term)
-			.limit(limit)
-			.toArray()
+                const term = searchTerm.toLowerCase()
 
-		return results
+                // Search by name, mobile, or email
+                let query = db.customers
+                        .where("customer_name")
+                        .startsWithIgnoreCase(term)
+                        .or("mobile_no")
+                        .startsWithIgnoreCase(term)
+                        .or("email_id")
+                        .startsWithIgnoreCase(term)
+
+                if (shouldLimit) {
+                        query = query.limit(limit)
+                }
+
+                const results = await query.toArray()
+
+                return results
 	} catch (error) {
 		console.error("Error searching cached customers:", error)
 		return []

--- a/POS/src/utils/offline/items.js
+++ b/POS/src/utils/offline/items.js
@@ -145,22 +145,30 @@ export const cacheCustomers = async (customers) => {
 
 // Search cached customers
 export const searchCachedCustomers = async (searchTerm, limit = 20) => {
-	try {
-		if (!searchTerm) {
-			return await db.customers.limit(limit).toArray();
-		}
+        try {
+                const shouldLimit = Number.isFinite(limit) && limit > 0;
+
+                if (!searchTerm) {
+                        return shouldLimit
+                                ? await db.customers.limit(limit).toArray()
+                                : await db.customers.toArray();
+                }
 
 		const term = searchTerm.toLowerCase();
 
-		const results = await db.customers
-			.where("customer_name")
-			.startsWithIgnoreCase(term)
-			.or("mobile_no")
-			.startsWithIgnoreCase(term)
-			.or("email_id")
-			.startsWithIgnoreCase(term)
-			.limit(limit)
-			.toArray();
+                let query = db.customers
+                        .where("customer_name")
+                        .startsWithIgnoreCase(term)
+                        .or("mobile_no")
+                        .startsWithIgnoreCase(term)
+                        .or("email_id")
+                        .startsWithIgnoreCase(term);
+
+                if (shouldLimit) {
+                        query = query.limit(limit);
+                }
+
+                const results = await query.toArray();
 
 		return results;
 	} catch (error) {

--- a/POS/src/workers/offline.worker.js
+++ b/POS/src/workers/offline.worker.js
@@ -574,13 +574,16 @@ async function searchCachedItems(searchTerm = "", limit = 50) {
 
 // Search cached customers
 async function searchCachedCustomers(searchTerm = "", limit = 20) {
-	try {
-		const db = await initDB()
-		const term = searchTerm.toLowerCase()
+        try {
+                const db = await initDB()
+                const term = searchTerm.toLowerCase()
+                const limitValue = Number.isFinite(limit) && limit > 0 ? limit : null
 
-		if (!term) {
-			return await db.table("customers").limit(limit).toArray()
-		}
+                if (!term) {
+                        return limitValue
+                                ? await db.table("customers").limit(limitValue).toArray()
+                                : await db.table("customers").toArray()
+                }
 
 		// Get all customers and filter in memory for 'includes' behavior
 		// This is fast because IndexedDB is already in-memory for small datasets
@@ -593,10 +596,10 @@ async function searchCachedCustomers(searchTerm = "", limit = 20) {
 				const id = (cust.name || "").toLowerCase()
 
 				return name.includes(term) || mobile.includes(term) || id.includes(term)
-			})
-			.slice(0, limit)
+                        })
+                        .slice(0, limitValue || undefined)
 
-		return results
+                return results
 	} catch (error) {
 		log.error("Error searching cached customers", error)
 		return []

--- a/pos_next/api/customers.py
+++ b/pos_next/api/customers.py
@@ -5,6 +5,7 @@ Handles customer search, creation, and management for POS operations
 
 import frappe
 from frappe import _
+from frappe.utils import cint
 
 
 @frappe.whitelist()
@@ -34,15 +35,21 @@ def get_customers(search_term="", pos_profile=None, limit=20):
 				filters["customer_group"] = profile_doc.customer_group
 				frappe.logger().debug(f"Filtering by customer_group: {profile_doc.customer_group}")
 
-		# Return all customers (for client-side filtering)
-		filters["disabled"] = 0
-		result = frappe.get_all(
-			"Customer",
-			filters=filters,
-			fields=["name", "customer_name", "mobile_no", "email_id"],
-			limit=limit,
-			order_by="customer_name asc"
-		)
+                # Return all customers (for client-side filtering)
+                filters["disabled"] = 0
+
+                # If limit is 0 or negative, fetch the exact customer count to return all
+                limit_value = cint(limit)
+                if limit_value <= 0:
+                        limit_value = frappe.db.count("Customer", filters)
+
+                result = frappe.get_all(
+                        "Customer",
+                        filters=filters,
+                        fields=["name", "customer_name", "mobile_no", "email_id"],
+                        limit=limit_value,
+                        order_by="customer_name asc"
+                )
 		frappe.logger().debug(f"get_customers returned {len(result)} customers")
 		return result
 	except Exception as e:


### PR DESCRIPTION
## Summary
- allow the customer API to return all customers when the limit is zero or negative
- update POS customer loading to request all customers instead of using a hardcoded 9999 cap
- adjust offline cache customer search helpers to support unlimited results

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921544be4608326ba848ba0ed2913c5)