### PR TITLE
Load all customers without hardcoded limit

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -751,12 +751,12 @@ const openUomDropdown = ref(null)
 const customersResource = createResource({
 	url: "pos_next.api.customers.get_customers",
 	makeParams() {
-		return {
-			search_term: "", // Empty to get all customers
-			pos_profile: props.posProfile,
-			limit: 9999, // Get all customers
-		}
-	},
+                return {
+                        search_term: "", // Empty to get all customers
+                        pos_profile: props.posProfile,
+                        limit: 0, // Get all customers
+                }
+        },
 	auto: false, // Don't auto-load - check offline status first
 	async onSuccess(data) {
 		const customers = data?.message || data || []
@@ -773,11 +773,11 @@ const customersResource = createResource({
 
 // Load customers from cache first (instant), then from server if online
 ;(async () => {
-	try {
-		// Always try cache first for instant load
-		const cachedCustomers = await offlineWorker.searchCachedCustomers("", 9999)
-		if (cachedCustomers && cachedCustomers.length > 0) {
-			allCustomers.value = cachedCustomers
+        try {
+                // Always try cache first for instant load
+                const cachedCustomers = await offlineWorker.searchCachedCustomers("", 0)
+                if (cachedCustomers && cachedCustomers.length > 0) {
+                        allCustomers.value = cachedCustomers
 			customersLoaded.value = true
 		}
 	} catch (error) {

--- a/POS/src/stores/customerSearch.js
+++ b/POS/src/stores/customerSearch.js
@@ -209,11 +209,11 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 
 		loading.value = true
 		try {
-			// Try to get from worker cache first
-			const cachedCustomers = await offlineWorker.searchCachedCustomers(
-				"",
-				9999,
-			)
+                        // Try to get from worker cache first
+                        const cachedCustomers = await offlineWorker.searchCachedCustomers(
+                                "",
+                                0,
+                        )
 
 			if (cachedCustomers && cachedCustomers.length > 0) {
 				allCustomers.value = cachedCustomers
@@ -222,12 +222,12 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 				)
 			} else if (!isOffline()) {
 				// Fetch from server if cache is empty and online
-				const response = await call("pos_next.api.customers.get_customers", {
-					pos_profile: posProfile,
-					search_term: "",
-					start: 0,
-					limit: 9999,
-				})
+                                const response = await call("pos_next.api.customers.get_customers", {
+                                        pos_profile: posProfile,
+                                        search_term: "",
+                                        start: 0,
+                                        limit: 0,
+                                })
 				const list = response?.message || response || []
 				allCustomers.value = list
 

--- a/POS/src/utils/offline/cache.js
+++ b/POS/src/utils/offline/cache.js
@@ -188,10 +188,10 @@ export const cacheCustomersFromServer = async (posProfile) => {
 		console.log("Fetching customers from server...")
 
 		const response = await call("pos_next.api.customers.get_customers", {
-			pos_profile: posProfile,
-			start: 0,
-			limit: 9999, // Get all customers
-		})
+                        pos_profile: posProfile,
+                        start: 0,
+                        limit: 0, // Get all customers
+                })
 
 		if (response.message && Array.isArray(response.message)) {
 			const customers = response.message

--- a/POS/src/utils/offline/items.js
+++ b/POS/src/utils/offline/items.js
@@ -145,22 +145,26 @@ export const cacheCustomers = async (customers) => {
 
 // Search cached customers
 export const searchCachedCustomers = async (searchTerm, limit = 20) => {
-	try {
-		if (!searchTerm) {
-			return await db.customers.limit(limit).toArray();
-		}
+        try {
+                if (!searchTerm) {
+                        return limit > 0
+                                ? await db.customers.limit(limit).toArray()
+                                : await db.customers.toArray();
+                }
 
 		const term = searchTerm.toLowerCase();
 
-		const results = await db.customers
-			.where("customer_name")
-			.startsWithIgnoreCase(term)
-			.or("mobile_no")
-			.startsWithIgnoreCase(term)
-			.or("email_id")
-			.startsWithIgnoreCase(term)
-			.limit(limit)
-			.toArray();
+                const query = db.customers
+                        .where("customer_name")
+                        .startsWithIgnoreCase(term)
+                        .or("mobile_no")
+                        .startsWithIgnoreCase(term)
+                        .or("email_id")
+                        .startsWithIgnoreCase(term);
+
+                const results = await (limit > 0
+                        ? query.limit(limit).toArray()
+                        : query.toArray());
 
 		return results;
 	} catch (error) {

--- a/POS/src/workers/offline.worker.js
+++ b/POS/src/workers/offline.worker.js
@@ -579,7 +579,9 @@ async function searchCachedCustomers(searchTerm = "", limit = 20) {
 		const term = searchTerm.toLowerCase()
 
 		if (!term) {
-			return await db.table("customers").limit(limit).toArray()
+			return limit > 0
+				? await db.table("customers").limit(limit).toArray()
+				: await db.table("customers").toArray()
 		}
 
 		// Get all customers and filter in memory for 'includes' behavior
@@ -594,7 +596,7 @@ async function searchCachedCustomers(searchTerm = "", limit = 20) {
 
 				return name.includes(term) || mobile.includes(term) || id.includes(term)
 			})
-			.slice(0, limit)
+			.slice(0, limit || allCustomers.length)
 
 		return results
 	} catch (error) {

--- a/pos_next/api/customers.py
+++ b/pos_next/api/customers.py
@@ -34,15 +34,16 @@ def get_customers(search_term="", pos_profile=None, limit=20):
 				filters["customer_group"] = profile_doc.customer_group
 				frappe.logger().debug(f"Filtering by customer_group: {profile_doc.customer_group}")
 
-		# Return all customers (for client-side filtering)
-		filters["disabled"] = 0
-		result = frappe.get_all(
-			"Customer",
-			filters=filters,
-			fields=["name", "customer_name", "mobile_no", "email_id"],
-			limit=limit,
-			order_by="customer_name asc"
-		)
+                # Return all customers (for client-side filtering)
+                filters["disabled"] = 0
+                customer_limit = limit if limit not in (None, 0) else frappe.db.count("Customer", filters)
+                result = frappe.get_all(
+                        "Customer",
+                        filters=filters,
+                        fields=["name", "customer_name", "mobile_no", "email_id"],
+                        limit=customer_limit,
+                        order_by="customer_name asc"
+                )
 		frappe.logger().debug(f"get_customers returned {len(result)} customers")
 		return result
 	except Exception as e:


### PR DESCRIPTION
## Summary
- request all customers by passing a zero limit from the POS UI, customer search store, and offline cache jobs
- allow offline worker customer searches to return full datasets when no limit is provided
- have the customer API compute the total count when a zero limit is requested so every customer is returned

## Testing
- not run (not requested)
