### PR TITLE
Add POS setting to toggle customer price list usage

### DIFF
--- a/POS/src/components/sale/InvoiceCart.vue
+++ b/POS/src/components/sale/InvoiceCart.vue
@@ -751,12 +751,12 @@ const openUomDropdown = ref(null)
 const customersResource = createResource({
 	url: "pos_next.api.customers.get_customers",
 	makeParams() {
-		return {
-			search_term: "", // Empty to get all customers
-			pos_profile: props.posProfile,
-			limit: 9999, // Get all customers
-		}
-	},
+                return {
+                        search_term: "", // Empty to get all customers
+                        pos_profile: props.posProfile,
+                        limit: 0, // Get all customers
+                }
+        },
 	auto: false, // Don't auto-load - check offline status first
 	async onSuccess(data) {
 		const customers = data?.message || data || []
@@ -773,11 +773,11 @@ const customersResource = createResource({
 
 // Load customers from cache first (instant), then from server if online
 ;(async () => {
-	try {
-		// Always try cache first for instant load
-		const cachedCustomers = await offlineWorker.searchCachedCustomers("", 9999)
-		if (cachedCustomers && cachedCustomers.length > 0) {
-			allCustomers.value = cachedCustomers
+        try {
+                // Always try cache first for instant load
+                const cachedCustomers = await offlineWorker.searchCachedCustomers("", 0)
+                if (cachedCustomers && cachedCustomers.length > 0) {
+                        allCustomers.value = cachedCustomers
 			customersLoaded.value = true
 		}
 	} catch (error) {

--- a/POS/src/components/settings/POSSettings.vue
+++ b/POS/src/components/settings/POSSettings.vue
@@ -257,16 +257,21 @@
 											<h4 class="text-sm font-semibold text-gray-900">Pricing & Discounts</h4>
 										</div>
 										<div class="space-y-3">
-											<CheckboxField
-												v-model="settings.tax_inclusive"
-												label="Tax Inclusive"
-												description="When enabled, displayed prices include tax. When disabled, tax is calculated separately. Changes apply immediately to your cart when you save."
-											/>
-											<NumberField
-												v-model="settings.max_discount_allowed"
-												label="Max Discount (%)"
-												description="Maximum discount per item"
-												:min="0"
+                                                                                        <CheckboxField
+                                                                                                v-model="settings.tax_inclusive"
+                                                                                                label="Tax Inclusive"
+                                                                                                description="When enabled, displayed prices include tax. When disabled, tax is calculated separately. Changes apply immediately to your cart when you save."
+                                                                                        />
+                                                                                        <CheckboxField
+                                                                                                v-model="settings.use_customer_price_list"
+                                                                                                label="Use Customer Price List"
+                                                                                                description="When enabled, pricing follows the selected customer's default price list. Disable to always use the POS Profile price list."
+                                                                                        />
+                                                                                        <NumberField
+                                                                                                v-model="settings.max_discount_allowed"
+                                                                                                label="Max Discount (%)"
+                                                                                                description="Maximum discount per item"
+                                                                                                :min="0"
 												:max="100"
 											/>
 											<CheckboxField
@@ -384,23 +389,24 @@ const loading = ref(true)
 const saving = ref(false)
 const warehousesList = ref([])
 const selectedWarehouse = ref(props.currentWarehouse || "")
-const settings = ref({
-	pos_profile: props.posProfile || "",
-	enabled: 1,
-	// Core Settings
-	max_discount_allowed: 0,
-	use_percentage_discount: 0,
-	allow_user_to_edit_additional_discount: 0,
-	allow_user_to_edit_item_discount: 1,
-	disable_rounded_total: 1,
-	allow_credit_sale: 0,
-	allow_return: 0,
-	allow_write_off_change: 0,
-	allow_partial_payment: 0,
-	silent_print: 0,
-	allow_negative_stock: 0,
-	tax_inclusive: 0,
-})
+        const settings = ref({
+                pos_profile: props.posProfile || "",
+                enabled: 1,
+                // Core Settings
+                max_discount_allowed: 0,
+                use_percentage_discount: 0,
+                allow_user_to_edit_additional_discount: 0,
+                allow_user_to_edit_item_discount: 1,
+                disable_rounded_total: 1,
+                allow_credit_sale: 0,
+                allow_return: 0,
+                allow_write_off_change: 0,
+                allow_partial_payment: 0,
+                silent_print: 0,
+                allow_negative_stock: 0,
+                tax_inclusive: 0,
+                use_customer_price_list: 0,
+        })
 
 // Stock Sync Settings (localStorage persisted)
 const stockSyncEnabled = ref(false)

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -833,10 +833,8 @@ const profileWarehouses = computed(() => {
         return []
 })
 
-const activePriceList = computed(() => cartStore.activePriceList)
-
 watch(
-        activePriceList,
+        () => cartStore.activePriceList.value,
         async (newPriceList, oldPriceList) => {
                 if (newPriceList === oldPriceList || !shiftStore.profileName) {
                         return

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -815,10 +815,10 @@ watch(
 
 // Computed for warehouses - returns all warehouses for the company
 const profileWarehouses = computed(() => {
-	if (warehousesList.value.length > 0) {
-		return warehousesList.value.map((w) => ({
-			name: w.name,
-			warehouse: w.warehouse_name || w.name,
+        if (warehousesList.value.length > 0) {
+                return warehousesList.value.map((w) => ({
+                        name: w.name,
+                        warehouse: w.warehouse_name || w.name,
 		}))
 	}
 	// Fallback to profile warehouse if API hasn't loaded yet
@@ -829,9 +829,31 @@ const profileWarehouses = computed(() => {
 				warehouse: shiftStore.profileWarehouse,
 			},
 		]
-	}
-	return []
+        }
+        return []
 })
+
+const activePriceList = computed(() => cartStore.activePriceList)
+
+watch(
+        activePriceList,
+        async (newPriceList, oldPriceList) => {
+                if (newPriceList === oldPriceList || !shiftStore.profileName) {
+                        return
+                }
+
+                itemStore.setPriceList(newPriceList)
+
+                if (itemsSelectorRef.value) {
+                        await itemsSelectorRef.value.loadItems()
+                }
+
+                if (cartStore.invoiceItems.length > 0) {
+                        await cartStore.refreshPricesForPriceList(newPriceList)
+                }
+        },
+        { immediate: true },
+)
 
 // Resize state
 let resizeState = null
@@ -979,7 +1001,7 @@ onMounted(async () => {
 		} else {
 			// Set POS profile and load tax rules
 			if (shiftStore.currentProfile) {
-				cartStore.posProfile = shiftStore.profileName
+                                cartStore.posProfile = shiftStore.currentProfile
 				cartStore.posOpeningShift = shiftStore.currentShift?.name
 
 				// Load POS Settings
@@ -1303,7 +1325,7 @@ onUnmounted(() => {
 async function handleShiftOpened() {
 	uiStore.showOpenShiftDialog = false
 	if (shiftStore.currentProfile) {
-		cartStore.posProfile = shiftStore.profileName
+                cartStore.posProfile = shiftStore.currentProfile
 		cartStore.posOpeningShift = shiftStore.currentShift?.name
 		// Load POS Settings first to get tax_inclusive setting
 		await posSettingsStore.loadSettings(shiftStore.profileName)
@@ -1598,21 +1620,22 @@ async function handleOptionSelected(option) {
 				showSuccess(`${variant.item_name} added to cart`)
 			}
 		} else if (option.type === "uom") {
-			const itemDetails = await cartStore.getItemDetailsResource.submit({
-				item_code: cartStore.pendingItem.item_code,
-				pos_profile: cartStore.posProfile,
-				customer: cartStore.customer?.name || cartStore.customer,
-				qty: cartStore.pendingItemQty,
-				uom: option.uom,
-			})
+                        const itemDetails = await cartStore.getItemDetailsResource.submit({
+                                item_code: cartStore.pendingItem.item_code,
+                                pos_profile: cartStore.posProfile,
+                                customer: cartStore.customer?.name || cartStore.customer,
+                                qty: cartStore.pendingItemQty,
+                                uom: option.uom,
+                                price_list: activePriceList.value,
+                        })
 
-			const itemToAdd = {
-				...cartStore.pendingItem,
-				uom: option.uom,
-				conversion_factor: option.conversion_factor,
-				rate: itemDetails.price_list_rate || itemDetails.rate,
-				price_list_rate: itemDetails.price_list_rate,
-			}
+                        const itemToAdd = {
+                                ...cartStore.pendingItem,
+                                uom: option.uom,
+                                conversion_factor: option.conversion_factor,
+                                rate: itemDetails?.price_list_rate ?? itemDetails?.rate ?? 0,
+                                price_list_rate: itemDetails?.price_list_rate ?? 0,
+                        }
 
 			if (itemToAdd.has_batch_no || itemToAdd.has_serial_no) {
 				cartStore.setPendingItem(itemToAdd, cartStore.pendingItemQty)

--- a/POS/src/pages/POSSale.vue
+++ b/POS/src/pages/POSSale.vue
@@ -833,8 +833,11 @@ const profileWarehouses = computed(() => {
         return []
 })
 
+// Track the active price list from the cart store for reuse in watchers and handlers
+const activePriceList = computed(() => cartStore.activePriceList.value)
+
 watch(
-        () => cartStore.activePriceList.value,
+        activePriceList,
         async (newPriceList, oldPriceList) => {
                 if (newPriceList === oldPriceList || !shiftStore.profileName) {
                         return

--- a/POS/src/stores/customerSearch.js
+++ b/POS/src/stores/customerSearch.js
@@ -209,11 +209,11 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 
 		loading.value = true
 		try {
-			// Try to get from worker cache first
-			const cachedCustomers = await offlineWorker.searchCachedCustomers(
-				"",
-				9999,
-			)
+                        // Try to get from worker cache first
+                        const cachedCustomers = await offlineWorker.searchCachedCustomers(
+                                "",
+                                0,
+                        )
 
 			if (cachedCustomers && cachedCustomers.length > 0) {
 				allCustomers.value = cachedCustomers
@@ -222,12 +222,12 @@ export const useCustomerSearchStore = defineStore("customerSearch", () => {
 				)
 			} else if (!isOffline()) {
 				// Fetch from server if cache is empty and online
-				const response = await call("pos_next.api.customers.get_customers", {
-					pos_profile: posProfile,
-					search_term: "",
-					start: 0,
-					limit: 9999,
-				})
+                                const response = await call("pos_next.api.customers.get_customers", {
+                                        pos_profile: posProfile,
+                                        search_term: "",
+                                        start: 0,
+                                        limit: 0,
+                                })
 				const list = response?.message || response || []
 				allCustomers.value = list
 

--- a/POS/src/stores/itemSearch.js
+++ b/POS/src/stores/itemSearch.js
@@ -24,12 +24,13 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 	const searchTerm = ref("")
 	const selectedItemGroup = ref(null)
 	const itemGroups = ref([])
-	const profileItemGroups = ref([]) // Item groups from POS Profile filter
-	const loading = ref(false)
-	const loadingMore = ref(false)
-	const searching = ref(false) // Separate loading state for search
-	const posProfile = ref(null)
-	const cartItems = ref([])
+        const profileItemGroups = ref([]) // Item groups from POS Profile filter
+        const loading = ref(false)
+        const loadingMore = ref(false)
+        const searching = ref(false) // Separate loading state for search
+        const posProfile = ref(null)
+        const priceList = ref(null)
+        const cartItems = ref([])
 
 	// Sorting state - for user-triggered sorting filters
 	const sortBy = ref(null) // Options: 'name', 'quantity', 'item_group', null (no sorting)
@@ -130,13 +131,17 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 			const groupObjects = groups.map(g => ({ item_group: g }))
 
 			// Reuse the standard fetch function
-			const items = await fetchItemsFromGroups(profile, groupObjects)
+                        const items = await fetchItemsFromGroups(
+                                profile,
+                                groupObjects,
+                                priceList.value,
+                        )
 
-			if (items.length > 0) {
-				await offlineWorker.cacheItems(items)
-				log.success(`Cached ${items.length} items from ${groups.length} group(s)`)
-				return items.length
-			}
+                        if (items.length > 0) {
+                                await offlineWorker.cacheItems(items, priceList.value)
+                                log.success(`Cached ${items.length} items from ${groups.length} group(s)`)
+                                return items.length
+                        }
 
 			return 0
 		} catch (error) {
@@ -586,8 +591,10 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 			return
 		}
 
-		posProfile.value = profile
-		loading.value = true
+                posProfile.value = profile
+                loading.value = true
+
+                const effectivePriceList = priceList.value || null
 
 		// Reset pagination state
 		currentOffset.value = 0
@@ -724,7 +731,11 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 
 				// Parallel fetch from multiple groups for optimal performance
 				// Example: Fetch "Bundles" (500 items) + "Electronics" (300 items) simultaneously
-				const fetchedItems = await fetchItemsFromGroups(profile, itemGroupFilters)
+                                const fetchedItems = await fetchItemsFromGroups(
+                                        profile,
+                                        itemGroupFilters,
+                                        effectivePriceList,
+                                )
 
 				// CRITICAL: Store ALL fetched items (not just first page)
 				// Why? Client-side filtering needs complete dataset to switch between groups instantly
@@ -741,7 +752,10 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 
 				if (fetchedItems.length > 0) {
 					// Cache ALL filtered items for offline use
-					await offlineWorker.cacheItems(fetchedItems)
+                                        await offlineWorker.cacheItems(
+                                                fetchedItems,
+                                                effectivePriceList,
+                                        )
 					cacheReady.value = true
 
 					// Mark data as fresh - prevents redundant fetches on page refresh
@@ -762,13 +776,14 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 				log.debug(`Fetching ${itemsPerPage.value} items (no filters)`)
 
 				// Fetch first batch (e.g., 20-50 items) for fast initial render
-				const response = await call("pos_next.api.items.get_items", {
-					pos_profile: profile,
-					search_term: "",
-					item_group: null, // No filter - get items from all groups
-					start: 0,
-					limit: itemsPerPage.value,
-				})
+                                const response = await call("pos_next.api.items.get_items", {
+                                        pos_profile: profile,
+                                        search_term: "",
+                                        item_group: null, // No filter - get items from all groups
+                                        start: 0,
+                                        limit: itemsPerPage.value,
+                                        price_list: effectivePriceList,
+                                })
 				const list = response?.message || response || []
 
 				if (list.length > 0) {
@@ -782,7 +797,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 					hasMore.value = true
 
 					// Cache first batch for offline support
-					await offlineWorker.cacheItems(list)
+                                        await offlineWorker.cacheItems(list, effectivePriceList)
 
 					// Mark data as fresh
 					serverDataFresh.value = true
@@ -821,21 +836,22 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 	 * Fetch items from specific item groups in parallel
 	 * Returns merged and deduplicated results
 	 */
-	async function fetchItemsFromGroups(profile, itemGroups) {
-		const fetchPromises = itemGroups.map(async (groupObj) => {
-			const itemGroup = groupObj.item_group
-			try {
-				const response = await call("pos_next.api.items.get_items", {
-					pos_profile: profile,
-					search_term: "",
-					item_group: itemGroup,
-					start: 0,
-					limit: 1000, // Get all items from this group
-				})
-				const items = response?.message || response || []
-				log.debug(`Fetched ${items.length} items from group: ${itemGroup}`)
-				return items
-			} catch (error) {
+        async function fetchItemsFromGroups(profile, itemGroups, priceListOverride = null) {
+                const fetchPromises = itemGroups.map(async (groupObj) => {
+                        const itemGroup = groupObj.item_group
+                        try {
+                                const response = await call("pos_next.api.items.get_items", {
+                                        pos_profile: profile,
+                                        search_term: "",
+                                        item_group: itemGroup,
+                                        start: 0,
+                                        limit: 1000, // Get all items from this group
+                                        price_list: priceListOverride,
+                                })
+                                const items = response?.message || response || []
+                                log.debug(`Fetched ${items.length} items from group: ${itemGroup}`)
+                                return items
+                        } catch (error) {
 				log.error(`Failed to fetch items from group: ${itemGroup}`, error)
 				return []
 			}
@@ -954,13 +970,14 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 			// Fetch next batch from server
 			// start: currentOffset (e.g., 50 after first batch)
 			// limit: itemsPerPage (e.g., 50 items per batch)
-			const response = await call("pos_next.api.items.get_items", {
-				pos_profile: posProfile.value,
-				search_term: "",
-				item_group: null, // No filter - get items from all groups
-				start: currentOffset.value,
-				limit: itemsPerPage.value,
-			})
+                        const response = await call("pos_next.api.items.get_items", {
+                                pos_profile: posProfile.value,
+                                search_term: "",
+                                item_group: null, // No filter - get items from all groups
+                                start: currentOffset.value,
+                                limit: itemsPerPage.value,
+                                price_list: priceList.value,
+                        })
 			const list = response?.message || response || []
 
 			if (list.length > 0) {
@@ -976,7 +993,7 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 				hasMore.value = list.length === itemsPerPage.value
 
 				// Cache new batch for offline support
-				await offlineWorker.cacheItems(list)
+                                await offlineWorker.cacheItems(list, priceList.value)
 
 				log.debug(`Loaded ${list.length} more items, total: ${totalItemsLoaded.value}`)
 			} else {
@@ -1035,18 +1052,19 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 		const fetchBatch = async () => {
 			try {
 				log.debug(`Background sync: fetching batch at offset ${offset}`)
-				const response = await call("pos_next.api.items.get_items", {
-					pos_profile: profile,
-					search_term: "",
-					item_group: null, // No filters for background sync
-					start: offset,
-					limit: batchSize,
-				})
+                                const response = await call("pos_next.api.items.get_items", {
+                                        pos_profile: profile,
+                                        search_term: "",
+                                        item_group: null, // No filters for background sync
+                                        start: offset,
+                                        limit: batchSize,
+                                        price_list: priceList.value,
+                                })
 				const list = response?.message || response || []
 
 				if (list.length > 0) {
 					// Cache the batch
-					await offlineWorker.cacheItems(list)
+                                await offlineWorker.cacheItems(list, priceList.value)
 					offset += list.length
 					batchCount++
 
@@ -1153,14 +1171,15 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 
 					// Now search server in background for fresh results
 					log.debug(`Searching server for: "${term}"`)
-					const response = await call("pos_next.api.items.get_items", {
-						pos_profile: posProfile.value,
-						search_term: term,
-						item_group: selectedItemGroup.value,
-						start: 0,
-						limit: searchLimit, // Dynamically adjusted based on device performance
-					})
-					const serverResults = response?.message || response || []
+                                        const response = await call("pos_next.api.items.get_items", {
+                                                pos_profile: posProfile.value,
+                                                search_term: term,
+                                                item_group: selectedItemGroup.value,
+                                                start: 0,
+                                                limit: searchLimit, // Dynamically adjusted based on device performance
+                                                price_list: priceList.value,
+                                        })
+                                        const serverResults = response?.message || response || []
 
 					if (serverResults.length > 0) {
 						// Update with fresh server results
@@ -1168,7 +1187,10 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 						log.success(`Found ${serverResults.length} items on server`)
 
 						// Cache server results for future searches
-						await offlineWorker.cacheItems(serverResults)
+                                                await offlineWorker.cacheItems(
+                                                        serverResults,
+                                                        priceList.value,
+                                                )
 
 						// If we didn't resolve with cache, resolve with server results
 						if (!cached || cached.length === 0) {
@@ -1338,10 +1360,17 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 	/**
 	 * Update cart items - delegates to stock store
 	 */
-	function setCartItems(items) {
-		cartItems.value = items
-		stockStore.reserve(items) // Simple!
-	}
+        function setCartItems(items) {
+                cartItems.value = items
+                stockStore.reserve(items) // Simple!
+        }
+
+        function setPriceList(newPriceList) {
+            priceList.value = newPriceList || null
+            // Invalidate caches so fresh prices are fetched for the new price list
+            serverDataFresh.value = false
+            clearBaseCache()
+        }
 
 	/**
 	 * Set POS Profile and load item group filters
@@ -1367,13 +1396,18 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 				})
 
 				// Extract item_groups from the profile
-				if (data?.pos_profile?.item_groups) {
-					profileItemGroups.value = data.pos_profile.item_groups
-					log.info(`Loaded ${profileItemGroups.value.length} item group filters from POS Profile`)
-				} else {
-					profileItemGroups.value = []
-					log.info("No item group filters in POS Profile")
-				}
+                                if (data?.pos_profile?.item_groups) {
+                                        profileItemGroups.value = data.pos_profile.item_groups
+                                        log.info(`Loaded ${profileItemGroups.value.length} item group filters from POS Profile`)
+                                } else {
+                                        profileItemGroups.value = []
+                                        log.info("No item group filters in POS Profile")
+                                }
+
+                                // Initialize price list from POS Profile if not already set
+                                if (!priceList.value) {
+                                        priceList.value = data?.pos_profile?.selling_price_list || null
+                                }
 
 				// Set up real-time listener for POS Profile updates
 				posProfileUpdateCleanup = onPosProfileUpdate(async (updateData) => {
@@ -1416,15 +1450,16 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 		selectedItemGroup,
 		itemGroups,
 		profileItemGroups,
-		loading,
-		loadingMore,
-		searching,
-		posProfile,
-		cartItems,
-		hasMore,
-		totalItemsLoaded,
-		currentOffset,
-		cacheReady,
+                loading,
+                loadingMore,
+                searching,
+                posProfile,
+                priceList,
+                cartItems,
+                hasMore,
+                totalItemsLoaded,
+                currentOffset,
+                cacheReady,
 		cacheSyncing,
 		cacheStats,
 		sortBy,
@@ -1446,10 +1481,11 @@ export const useItemSearchStore = defineStore("itemSearch", () => {
 		getItem,
 		setSearchTerm,
 		clearSearch,
-		setSelectedItemGroup,
-		setCartItems, // Delegates to stock store for reservations
-		setPosProfile,
-		startBackgroundCacheSync,
+                setSelectedItemGroup,
+                setCartItems, // Delegates to stock store for reservations
+                setPriceList,
+                setPosProfile,
+                startBackgroundCacheSync,
 		stopBackgroundCacheSync,
 		cleanup,
 		invalidateCache,

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -64,7 +64,10 @@ export const usePOSCartStore = defineStore("posCart", () => {
                         posProfile.value?.price_list ||
                         null
 
-                if (settingsStore.isEnabled && settingsStore.useCustomerPriceList) {
+                if (
+                        settingsStore.isEnabled.value &&
+                        settingsStore.useCustomerPriceList.value
+                ) {
                         const customerPriceList =
                                 customer.value?.default_price_list || customer.value?.price_list
 

--- a/POS/src/stores/posCart.js
+++ b/POS/src/stores/posCart.js
@@ -55,9 +55,26 @@ export const usePOSCartStore = defineStore("posCart", () => {
 	const { showSuccess, showError, showWarning } = useToast()
 
 	// Computed
-	const itemCount = computed(() => invoiceItems.value.length)
-	const isEmpty = computed(() => invoiceItems.value.length === 0)
-	const hasCustomer = computed(() => !!customer.value)
+        const itemCount = computed(() => invoiceItems.value.length)
+        const isEmpty = computed(() => invoiceItems.value.length === 0)
+        const hasCustomer = computed(() => !!customer.value)
+        const activePriceList = computed(() => {
+                const profilePriceList =
+                        posProfile.value?.selling_price_list ||
+                        posProfile.value?.price_list ||
+                        null
+
+                if (settingsStore.isEnabled && settingsStore.useCustomerPriceList) {
+                        const customerPriceList =
+                                customer.value?.default_price_list || customer.value?.price_list
+
+                        if (customerPriceList) {
+                                return customerPriceList
+                        }
+                }
+
+                return profilePriceList
+        })
 
 	// Actions
 	function addItem(item, qty = 1, autoAdd = false, currentProfile = null) {
@@ -566,21 +583,23 @@ export const usePOSCartStore = defineStore("posCart", () => {
 			const cartItem = invoiceItems.value.find((i) => i.item_code === itemCode)
 			if (!cartItem) return
 
-			const itemDetails = await getItemDetailsResource.submit({
-				item_code: itemCode,
-				pos_profile: posProfile.value,
-				customer: customer.value?.name || customer.value,
-				qty: cartItem.quantity,
-				uom: newUom,
-			})
+                        const itemDetails = await getItemDetailsResource.submit({
+                                item_code: itemCode,
+                                pos_profile: posProfile.value,
+                                customer: customer.value?.name || customer.value,
+                                qty: cartItem.quantity,
+                                uom: newUom,
+                                price_list: activePriceList.value,
+                        })
 
 			const uomData = cartItem.item_uoms?.find((u) => u.uom === newUom)
 
 			cartItem.uom = newUom
 			cartItem.conversion_factor =
 				uomData?.conversion_factor || itemDetails.conversion_factor || 1
-			cartItem.rate = itemDetails.price_list_rate || itemDetails.rate
-			cartItem.price_list_rate = itemDetails.price_list_rate
+                        const newRate = itemDetails?.price_list_rate ?? itemDetails?.rate ?? 0
+                        cartItem.rate = newRate
+                        cartItem.price_list_rate = itemDetails?.price_list_rate ?? 0
 
 			recalculateItem(cartItem)
 
@@ -591,23 +610,24 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		}
 	}
 
-	async function updateItemDetails(itemCode, updatedDetails) {
-		try {
-			const cartItem = invoiceItems.value.find((i) => i.item_code === itemCode)
-			if (!cartItem) {
-				throw new Error("Item not found in cart")
+        async function updateItemDetails(itemCode, updatedDetails) {
+                try {
+                        const cartItem = invoiceItems.value.find((i) => i.item_code === itemCode)
+                        if (!cartItem) {
+                                throw new Error("Item not found in cart")
 			}
 
 			// If UOM changed, fetch new rate from server
 			if (updatedDetails.uom && updatedDetails.uom !== cartItem.uom) {
 				try {
-					const itemDetails = await getItemDetailsResource.submit({
-						item_code: itemCode,
-						pos_profile: posProfile.value,
-						customer: customer.value?.name || customer.value,
-						qty: updatedDetails.quantity || cartItem.quantity,
-						uom: updatedDetails.uom,
-					})
+                                        const itemDetails = await getItemDetailsResource.submit({
+                                                item_code: itemCode,
+                                                pos_profile: posProfile.value,
+                                                customer: customer.value?.name || customer.value,
+                                                qty: updatedDetails.quantity || cartItem.quantity,
+                                                uom: updatedDetails.uom,
+                                                price_list: activePriceList.value,
+                                        })
 
 					const uomData = cartItem.item_uoms?.find(
 						(u) => u.uom === updatedDetails.uom,
@@ -617,8 +637,13 @@ export const usePOSCartStore = defineStore("posCart", () => {
 					cartItem.uom = updatedDetails.uom
 					cartItem.conversion_factor =
 						uomData?.conversion_factor || itemDetails.conversion_factor || 1
-					cartItem.rate = itemDetails.price_list_rate || itemDetails.rate
-					cartItem.price_list_rate = itemDetails.price_list_rate
+                                        const updatedRate =
+                                                itemDetails?.price_list_rate ??
+                                                itemDetails?.rate ??
+                                                0
+                                        cartItem.rate = updatedRate
+                                        cartItem.price_list_rate =
+                                                itemDetails?.price_list_rate ?? 0
 				} catch (error) {
 					console.warn(
 						"Failed to fetch UOM details, using provided rate:",
@@ -663,9 +688,45 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		} catch (error) {
 			console.error("Error updating item details:", error)
 			showError(parseError(error) || "Failed to update item. Please try again.")
-			return false
-		}
-	}
+                        return false
+                }
+        }
+
+        async function refreshPricesForPriceList(priceListOverride = null) {
+                if (invoiceItems.value.length === 0) {
+                        return
+                }
+
+                const priceListToUse = priceListOverride || activePriceList.value
+
+                for (const item of invoiceItems.value) {
+                        try {
+                                const itemDetails = await getItemDetailsResource.submit({
+                                        item_code: item.item_code,
+                                        pos_profile: posProfile.value,
+                                        customer: customer.value?.name || customer.value,
+                                        qty: item.quantity,
+                                        uom: item.uom,
+                                        price_list: priceListToUse,
+                                })
+
+                                const newRate =
+                                        itemDetails?.price_list_rate ?? itemDetails?.rate ?? 0
+
+                                item.rate = newRate
+                                item.price_list_rate = itemDetails?.price_list_rate ?? 0
+
+                                recalculateItem(item)
+                        } catch (error) {
+                                console.error(
+                                        `Error refreshing price for ${item.item_code}:`,
+                                        error,
+                                )
+                        }
+                }
+
+                rebuildIncrementalCache()
+        }
 
 	// Performance: Cache previous item codes hash to avoid unnecessary recalculations
 	let previousItemCodesHash = ""
@@ -673,7 +734,7 @@ export const usePOSCartStore = defineStore("posCart", () => {
 	let cachedItemGroups = []
 	let cachedBrands = []
 
-	function syncOfferSnapshot() {
+        function syncOfferSnapshot() {
 		// Only sync if values are initialized
 		if (subtotal.value !== undefined && invoiceItems.value) {
 			// Create hash for item codes to detect actual changes
@@ -743,29 +804,30 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		{ immediate: true, flush: "post" },
 	)
 
-	return {
-		// State
-		invoiceItems,
-		customer,
-		subtotal,
-		totalTax,
-		totalDiscount,
-		grandTotal,
-		posProfile,
-		posOpeningShift,
-		payments,
-		additionalDiscount,
-		taxInclusive,
-		pendingItem,
-		pendingItemQty,
-		appliedOffers,
-		appliedCoupon,
-		selectionMode,
-		suppressOfferReapply,
-		// Computed
-		itemCount,
-		isEmpty,
-		hasCustomer,
+        return {
+                // State
+                invoiceItems,
+                customer,
+                subtotal,
+                totalTax,
+                totalDiscount,
+                grandTotal,
+                posProfile,
+                posOpeningShift,
+                payments,
+                additionalDiscount,
+                taxInclusive,
+                pendingItem,
+                pendingItemQty,
+                appliedOffers,
+                appliedCoupon,
+                selectionMode,
+                suppressOfferReapply,
+                activePriceList,
+                // Computed
+                itemCount,
+                isEmpty,
+                hasCustomer,
 
 		// Actions
 		addItem,
@@ -782,14 +844,15 @@ export const usePOSCartStore = defineStore("posCart", () => {
 		applyDiscountToCart,
 		removeDiscountFromCart,
 		applyOffer,
-		removeOffer,
-		reapplyOffer,
-		changeItemUOM,
-		updateItemDetails,
-		getItemDetailsResource,
-		recalculateItem,
-		rebuildIncrementalCache,
-		applyOffersResource,
+                removeOffer,
+                reapplyOffer,
+                changeItemUOM,
+                updateItemDetails,
+                refreshPricesForPriceList,
+                getItemDetailsResource,
+                recalculateItem,
+                rebuildIncrementalCache,
+                applyOffersResource,
 		buildInvoiceDataForOffers,
 	}
 })

--- a/POS/src/stores/posSettings.js
+++ b/POS/src/stores/posSettings.js
@@ -30,11 +30,12 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		create_only_sales_order: 0,
 		allow_return_without_invoice: 0,
 		allow_free_batch_return: 0,
-		allow_print_draft_invoices: 0,
-		// Pricing & Display
-		decimal_precision: "2",
-		// Customer Settings
-		allow_customer_purchase_order: 0,
+                allow_print_draft_invoices: 0,
+                // Pricing & Display
+                decimal_precision: "2",
+                use_customer_price_list: 0,
+                // Customer Settings
+                allow_customer_purchase_order: 0,
 		allow_duplicate_customer_names: 0,
 		fetch_coupon: 0,
 		// Printing
@@ -134,10 +135,13 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 	const allowCustomerPurchaseOrder = computed(() =>
 		Boolean(settings.value.allow_customer_purchase_order),
 	)
-	const allowDuplicateCustomerNames = computed(() =>
-		Boolean(settings.value.allow_duplicate_customer_names),
-	)
-	const fetchCoupon = computed(() => Boolean(settings.value.fetch_coupon))
+        const allowDuplicateCustomerNames = computed(() =>
+                Boolean(settings.value.allow_duplicate_customer_names),
+        )
+        const fetchCoupon = computed(() => Boolean(settings.value.fetch_coupon))
+        const useCustomerPriceList = computed(() =>
+                Boolean(settings.value.use_customer_price_list),
+        )
 
 	// Computed - Printing
 	const allowPrintLastInvoice = computed(() =>
@@ -237,11 +241,12 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 			allow_select_sales_order: 0,
 			create_only_sales_order: 0,
 			allow_return_without_invoice: 0,
-			allow_free_batch_return: 0,
-			allow_print_draft_invoices: 0,
-			decimal_precision: "2",
-			allow_customer_purchase_order: 0,
-			allow_duplicate_customer_names: 0,
+                        allow_free_batch_return: 0,
+                        allow_print_draft_invoices: 0,
+                        decimal_precision: "2",
+                        use_customer_price_list: 0,
+                        allow_customer_purchase_order: 0,
+                        allow_duplicate_customer_names: 0,
 			fetch_coupon: 0,
 			allow_print_last_invoice: 0,
 			silent_print: 0,
@@ -344,12 +349,13 @@ export const usePOSSettingsStore = defineStore("posSettings", () => {
 		allowPrintDraftInvoices,
 
 		// Computed - Pricing & Display
-		decimalPrecision,
+                decimalPrecision,
 
-		// Computed - Customer Settings
-		allowCustomerPurchaseOrder,
-		allowDuplicateCustomerNames,
-		fetchCoupon,
+                // Computed - Customer Settings
+                allowCustomerPurchaseOrder,
+                allowDuplicateCustomerNames,
+                fetchCoupon,
+                useCustomerPriceList,
 
 		// Computed - Printing
 		allowPrintLastInvoice,

--- a/POS/src/utils/offline/cache.js
+++ b/POS/src/utils/offline/cache.js
@@ -188,10 +188,10 @@ export const cacheCustomersFromServer = async (posProfile) => {
 		console.log("Fetching customers from server...")
 
 		const response = await call("pos_next.api.customers.get_customers", {
-			pos_profile: posProfile,
-			start: 0,
-			limit: 9999, // Get all customers
-		})
+                        pos_profile: posProfile,
+                        start: 0,
+                        limit: 0, // Get all customers
+                })
 
 		if (response.message && Array.isArray(response.message)) {
 			const customers = response.message

--- a/POS/src/utils/offline/items.js
+++ b/POS/src/utils/offline/items.js
@@ -145,22 +145,26 @@ export const cacheCustomers = async (customers) => {
 
 // Search cached customers
 export const searchCachedCustomers = async (searchTerm, limit = 20) => {
-	try {
-		if (!searchTerm) {
-			return await db.customers.limit(limit).toArray();
-		}
+        try {
+                if (!searchTerm) {
+                        return limit > 0
+                                ? await db.customers.limit(limit).toArray()
+                                : await db.customers.toArray();
+                }
 
 		const term = searchTerm.toLowerCase();
 
-		const results = await db.customers
-			.where("customer_name")
-			.startsWithIgnoreCase(term)
-			.or("mobile_no")
-			.startsWithIgnoreCase(term)
-			.or("email_id")
-			.startsWithIgnoreCase(term)
-			.limit(limit)
-			.toArray();
+                const query = db.customers
+                        .where("customer_name")
+                        .startsWithIgnoreCase(term)
+                        .or("mobile_no")
+                        .startsWithIgnoreCase(term)
+                        .or("email_id")
+                        .startsWithIgnoreCase(term);
+
+                const results = await (limit > 0
+                        ? query.limit(limit).toArray()
+                        : query.toArray());
 
 		return results;
 	} catch (error) {

--- a/POS/src/utils/offline/workerClient.js
+++ b/POS/src/utils/offline/workerClient.js
@@ -395,9 +395,9 @@ class OfflineWorkerClient {
 		return this.sendMessage("SEARCH_CUSTOMERS", { searchTerm, limit })
 	}
 
-	async cacheItems(items) {
-		return this.sendMessage("CACHE_ITEMS", { items })
-	}
+        async cacheItems(items, priceList = null) {
+                return this.sendMessage("CACHE_ITEMS", { items, priceList })
+        }
 
 	async cacheCustomers(customers) {
 		return this.sendMessage("CACHE_CUSTOMERS", { customers })

--- a/POS/src/workers/offline.worker.js
+++ b/POS/src/workers/offline.worker.js
@@ -579,7 +579,9 @@ async function searchCachedCustomers(searchTerm = "", limit = 20) {
 		const term = searchTerm.toLowerCase()
 
 		if (!term) {
-			return await db.table("customers").limit(limit).toArray()
+			return limit > 0
+				? await db.table("customers").limit(limit).toArray()
+				: await db.table("customers").toArray()
 		}
 
 		// Get all customers and filter in memory for 'includes' behavior
@@ -594,7 +596,7 @@ async function searchCachedCustomers(searchTerm = "", limit = 20) {
 
 				return name.includes(term) || mobile.includes(term) || id.includes(term)
 			})
-			.slice(0, limit)
+			.slice(0, limit || allCustomers.length)
 
 		return results
 	} catch (error) {

--- a/POS/src/workers/offline.worker.js
+++ b/POS/src/workers/offline.worker.js
@@ -612,10 +612,10 @@ async function searchCachedCustomers(searchTerm = "", limit = 20) {
  * @param {Array<Object>} items - Items to cache
  * @returns {Promise<Object>} Result with count and timing
  */
-async function cacheItemsFromServer(items) {
-	if (!items || items.length === 0) {
-		return { success: true, count: 0, duration: 0 }
-	}
+async function cacheItemsFromServer(items, priceListOverride = null) {
+        if (!items || items.length === 0) {
+                return { success: true, count: 0, duration: 0 }
+        }
 
 	const startTime = performance.now()
 
@@ -640,16 +640,20 @@ async function cacheItemsFromServer(items) {
 
 				// Extract and bulk insert prices
 				// CRITICAL: Compound primary key requires valid price_list AND item_code
-				const prices = batch
-					.filter(item => {
-						// Must have item_code (mandatory)
-						if (!item.item_code) return false
+                                const prices = batch
+                                        .filter(item => {
+                                                // Must have item_code (mandatory)
+                                                if (!item.item_code) return false
 						// Must have some price data
 						return item.rate || item.price_list_rate
 					})
 					.map(item => {
 						// Provide default price_list if missing (prevents key constraint violations)
-						const priceList = item.selling_price_list || item.price_list || "Standard"
+                                                const priceList =
+                                                        priceListOverride ||
+                                                        item.selling_price_list ||
+                                                        item.price_list ||
+                                                        "Standard"
 
 						return {
 							price_list: priceList,
@@ -1314,9 +1318,12 @@ self.onmessage = async (event) => {
 				result = await searchCachedCustomers(payload.searchTerm, payload.limit)
 				break
 
-			case "CACHE_ITEMS":
-				result = await cacheItemsFromServer(payload.items)
-				break
+                        case "CACHE_ITEMS":
+                                result = await cacheItemsFromServer(
+                                        payload.items,
+                                        payload.priceList,
+                                )
+                                break
 
 			case "CACHE_CUSTOMERS":
 				result = await cacheCustomersFromServer(payload.customers)

--- a/pos_next/api/customers.py
+++ b/pos_next/api/customers.py
@@ -34,15 +34,16 @@ def get_customers(search_term="", pos_profile=None, limit=20):
 				filters["customer_group"] = profile_doc.customer_group
 				frappe.logger().debug(f"Filtering by customer_group: {profile_doc.customer_group}")
 
-		# Return all customers (for client-side filtering)
-		filters["disabled"] = 0
-		result = frappe.get_all(
-			"Customer",
-			filters=filters,
-			fields=["name", "customer_name", "mobile_no", "email_id"],
-			limit=limit,
-			order_by="customer_name asc"
-		)
+                # Return all customers (for client-side filtering)
+                filters["disabled"] = 0
+                customer_limit = limit if limit not in (None, 0) else frappe.db.count("Customer", filters)
+                result = frappe.get_all(
+                        "Customer",
+                        filters=filters,
+                        fields=["name", "customer_name", "mobile_no", "email_id"],
+                        limit=customer_limit,
+                        order_by="customer_name asc"
+                )
 		frappe.logger().debug(f"get_customers returned {len(result)} customers")
 		return result
 	except Exception as e:

--- a/pos_next/api/customers.py
+++ b/pos_next/api/customers.py
@@ -40,7 +40,13 @@ def get_customers(search_term="", pos_profile=None, limit=20):
                 result = frappe.get_all(
                         "Customer",
                         filters=filters,
-                        fields=["name", "customer_name", "mobile_no", "email_id"],
+                        fields=[
+                                "name",
+                                "customer_name",
+                                "mobile_no",
+                                "email_id",
+                                "default_price_list",
+                        ],
                         limit=customer_limit,
                         order_by="customer_name asc"
                 )

--- a/pos_next/api/items.py
+++ b/pos_next/api/items.py
@@ -806,7 +806,7 @@ def _calculate_bundle_availability_bulk(bundle_codes, warehouse):
 
 
 @frappe.whitelist()
-def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20):
+def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20, price_list=None):
 	"""Get items for POS with stock, price, and tax details"""
 	try:
 		pos_profile_doc = frappe.get_cached_doc("POS Profile", pos_profile)
@@ -937,17 +937,17 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20)
 					conversion_map[row.parent][row.uom] = row.conversion_factor
 
 		# UOM-specific prices - batch query ALL prices for all items
-		if item_codes:
-			prices = frappe.db.sql(
-				"""
-				SELECT item_code, uom, price_list_rate
-				FROM `tabItem Price`
-				WHERE item_code IN %s AND price_list = %s
-				ORDER BY item_code, uom
-				""",
-				[item_codes, pos_profile_doc.selling_price_list],
-				as_dict=1,
-			)
+                if item_codes:
+                        prices = frappe.db.sql(
+                                """
+                                SELECT item_code, uom, price_list_rate
+                                FROM `tabItem Price`
+                                WHERE item_code IN %s AND price_list = %s
+                                ORDER BY item_code, uom
+                                """,
+                                [item_codes, selected_price_list],
+                                as_dict=1,
+                        )
 			for price in prices:
 				uom_prices_map.setdefault(price["item_code"], {})[price["uom"]] = price["price_list_rate"]
 
@@ -1024,16 +1024,16 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20)
 			if not price_row and item.get("has_variants"):
 				variant_prices = frappe.db.sql(
 					"""
-					SELECT MIN(ip.price_list_rate) as min_price
-					FROM `tabItem Price` ip
-					INNER JOIN `tabItem` i ON i.name = ip.item_code
-					WHERE i.variant_of = %s
-					AND ip.price_list = %s
-					AND i.disabled = 0
-					""",
-					[item["item_code"], pos_profile_doc.selling_price_list],
-					as_dict=1,
-				)
+                                        SELECT MIN(ip.price_list_rate) as min_price
+                                        FROM `tabItem Price` ip
+                                        INNER JOIN `tabItem` i ON i.name = ip.item_code
+                                        WHERE i.variant_of = %s
+                                        AND ip.price_list = %s
+                                        AND i.disabled = 0
+                                        """,
+                                        [item["item_code"], selected_price_list],
+                                        as_dict=1,
+                                )
 				derived_price = (
 					variant_prices[0]["min_price"]
 					if variant_prices and variant_prices[0].get("min_price")
@@ -1064,12 +1064,14 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20)
 				display_rate = flt(derived_price)
 				display_uom = stock_uom
 
-			item["rate"] = display_rate
-			item["price_list_rate"] = display_rate
-			item["uom"] = display_uom
-			item["price_uom"] = display_uom
-			item["conversion_factor"] = 1
-			item["price_list_rate_price_uom"] = display_rate
+                        item["rate"] = display_rate
+                        item["price_list_rate"] = display_rate
+                        item["uom"] = display_uom
+                        item["price_uom"] = display_uom
+                        item["conversion_factor"] = 1
+                        item["price_list_rate_price_uom"] = display_rate
+                        item["selling_price_list"] = selected_price_list
+                        item["price_list"] = selected_price_list
 
 			# ===================================================================
 			# STOCK QUANTITY ASSIGNMENT: Stock Items vs Product Bundles
@@ -1132,7 +1134,7 @@ def get_items(pos_profile, search_term=None, item_group=None, start=0, limit=20)
 
 
 @frappe.whitelist()
-def get_item_details(item_code, pos_profile, customer=None, qty=1, uom=None):
+def get_item_details(item_code, pos_profile, customer=None, qty=1, uom=None, price_list=None):
 	"""Get detailed item info including price, tax, stock"""
 	try:
 		# Parse pos_profile if it's a JSON string
@@ -1149,8 +1151,11 @@ def get_item_details(item_code, pos_profile, customer=None, qty=1, uom=None):
 		if not pos_profile:
 			frappe.throw(_("POS Profile is required"))
 
-		pos_profile_doc = frappe.get_cached_doc("POS Profile", pos_profile)
-		item_doc = frappe.get_cached_doc("Item", item_code)
+                pos_profile_doc = frappe.get_cached_doc("POS Profile", pos_profile)
+                item_doc = frappe.get_cached_doc("Item", item_code)
+
+                # Prefer explicitly provided price list (e.g., from Customer), fallback to POS Profile
+                selected_price_list = price_list or pos_profile_doc.selling_price_list
 
 		# Check if item is allowed for sales
 		if not item_doc.is_sales_item:
@@ -1170,12 +1175,12 @@ def get_item_details(item_code, pos_profile, customer=None, qty=1, uom=None):
 		if uom:
 			item["uom"] = uom
 
-		return get_item_detail(
-			item=json.dumps(item),
-			warehouse=pos_profile_doc.warehouse,
-			price_list=pos_profile_doc.selling_price_list,
-			company=pos_profile_doc.company,
-		)
+                return get_item_detail(
+                        item=json.dumps(item),
+                        warehouse=pos_profile_doc.warehouse,
+                        price_list=selected_price_list,
+                        company=pos_profile_doc.company,
+                )
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), "Get Item Details Error")
 		frappe.throw(_("Error fetching item details: {0}").format(str(e)))

--- a/pos_next/pos_next/doctype/pos_settings/pos_settings.json
+++ b/pos_next/pos_next/doctype/pos_settings/pos_settings.json
@@ -36,6 +36,7 @@
   "section_break_pricing",
   "decimal_precision",
   "tax_inclusive",
+  "use_customer_price_list",
   "section_break_customer",
   "allow_customer_purchase_order",
   "allow_duplicate_customer_names",
@@ -272,6 +273,13 @@
    "fieldtype": "Check",
    "label": "Tax Inclusive",
    "description": "Automatically set taxes as included in item prices. When enabled, displayed prices include tax amounts."
+  },
+  {
+   "default": "0",
+   "fieldname": "use_customer_price_list",
+   "fieldtype": "Check",
+   "label": "Use Customer Price List",
+   "description": "When enabled, the POS will price items using the selected customer's default price list. Disable to always use the POS Profile price list."
   },
   {
    "collapsible": 1,


### PR DESCRIPTION
## Summary
- add a Sales Management toggle to enable or disable pricing by the customer's default price list
- expose the new customer price list setting through the POS settings store and existing APIs
- respect the toggle when choosing the active price list for the item selector and cart pricing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216e550ff88326a1b8fc4f887bb50a)